### PR TITLE
refactor: improve architecture and add edge case tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive", "alloc"], default-features = fa
 serde_json = { version = "1.0", features = ["alloc"], default-features = false }
 boon = "0.6"
 murmurhash3 = "0.0.5"
+thiserror = "2.0"
 # Override ahash to avoid SIMD/AES-NI instructions that break Chicory WASM compatibility
 # ahash is pulled in by boon and uses AES-NI by default
 # We disable default features and use compile-time-rng to avoid runtime randomness

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,13 @@
 //! Error types for the flagd-evaluator library.
 //!
-//! This module provides structured error types that serialize to JSON
-//! for consistent error handling across the WASM boundary.
+//! This module provides structured error types using thiserror for consistent
+//! error handling across the library and WASM boundary.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// The type of error that occurred during evaluation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorType {
     /// Error parsing JSON input
@@ -17,10 +18,17 @@ pub enum ErrorType {
     MemoryError,
     /// Invalid input provided
     InvalidInput,
+    /// Flag not found
+    FlagNotFound,
+    /// Type mismatch in flag value
+    TypeMismatch,
+    /// Configuration validation error
+    ValidationError,
 }
 
 /// Represents an error that occurred during evaluation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
+#[error("{error_type:?}: {message}")]
 pub struct EvaluatorError {
     /// Human-readable error message
     pub message: String,
@@ -78,15 +86,51 @@ impl EvaluatorError {
             error_type: ErrorType::InvalidInput,
         }
     }
-}
 
-impl std::fmt::Display for EvaluatorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}: {}", self.error_type, self.message)
+    /// Creates a new flag not found error.
+    ///
+    /// # Arguments
+    /// * `flag_key` - The key of the flag that was not found
+    pub fn flag_not_found(flag_key: impl Into<String>) -> Self {
+        Self {
+            message: format!("Flag not found: {}", flag_key.into()),
+            error_type: ErrorType::FlagNotFound,
+        }
+    }
+
+    /// Creates a new type mismatch error.
+    ///
+    /// # Arguments
+    /// * `message` - Description of the type mismatch
+    pub fn type_mismatch(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            error_type: ErrorType::TypeMismatch,
+        }
+    }
+
+    /// Creates a new validation error.
+    ///
+    /// # Arguments
+    /// * `message` - Description of the validation failure
+    pub fn validation_error(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            error_type: ErrorType::ValidationError,
+        }
+    }
+
+    /// Converts the error to a JSON string.
+    pub fn to_json_string(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| {
+            format!(
+                r#"{{"error_type":"{}","message":"{}"}}"#,
+                serde_json::to_string(&self.error_type).unwrap_or_default(),
+                self.message
+            )
+        })
     }
 }
-
-impl std::error::Error for EvaluatorError {}
 
 #[cfg(test)]
 mod tests {
@@ -104,5 +148,33 @@ mod tests {
         let err = EvaluatorError::evaluation_error("eval failed");
         let display = format!("{}", err);
         assert!(display.contains("eval failed"));
+        assert!(display.contains("EvaluationError"));
+    }
+
+    #[test]
+    fn test_flag_not_found_error() {
+        let err = EvaluatorError::flag_not_found("my-flag");
+        assert_eq!(err.error_type, ErrorType::FlagNotFound);
+        assert!(err.message.contains("my-flag"));
+    }
+
+    #[test]
+    fn test_type_mismatch_error() {
+        let err = EvaluatorError::type_mismatch("expected boolean, got string");
+        assert_eq!(err.error_type, ErrorType::TypeMismatch);
+    }
+
+    #[test]
+    fn test_validation_error() {
+        let err = EvaluatorError::validation_error("invalid config");
+        assert_eq!(err.error_type, ErrorType::ValidationError);
+    }
+
+    #[test]
+    fn test_error_to_json() {
+        let err = EvaluatorError::parse_error("test");
+        let json = err.to_json_string();
+        assert!(json.contains("parse_error"));
+        assert!(json.contains("test"));
     }
 }


### PR DESCRIPTION
- Extract generic evaluator dispatcher to eliminate type-specific duplication in evaluator.rs (~80 lines reduced via evaluate_with<F>() method)
- Fix silent memory allocation failure by ensuring empty strings return non-null pointers, allowing callers to distinguish from allocation errors
- Standardize error types with thiserror crate for consistent error handling
- Use RefCell for WASM singleton instead of Mutex (semantically correct for single-threaded WASM, with Mutex fallback for native targets)
- Add comprehensive edge case tests for operators and memory management:
  - Fractional operator: single bucket, unequal weights
  - Unicode: flag keys, context values, emoji in variants
  - Memory: large allocations, consecutive alloc/dealloc
  - Targeting: deeply nested rules, flag removal/re-addition
  - Semantic versioning edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a brief description of your changes -->

## Related Issue

<!-- Link to the related issue(s) -->
Closes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature (minor version bump)
- [ ] `fix`: Bug fix (patch version bump)
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Maintenance tasks, dependency updates
- [ ] `refactor`: Code refactoring without functional changes
- [ ] `test`: Adding or updating tests
- [ ] `ci`: CI/CD changes
- [ ] `perf`: Performance improvements
- [ ] `build`: Build system changes
- [ ] `style`: Code style/formatting changes

## PR Title Format

**IMPORTANT**: Since we use squash and merge, your PR title will become the commit message. Please ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format:

```
<type>(<optional-scope>): <description>
```

### Examples:
- `feat(operators): add new string comparison operator`
- `fix(wasm): correct memory allocation bug`
- `docs: update API examples in README`
- `chore(deps): update rust dependencies`

For breaking changes, use `!` after the type/scope or include `BREAKING CHANGE:` in the PR description:
- `feat(api)!: redesign evaluation API`

## Testing

<!-- Describe the testing you've performed -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)
- [ ] Code is formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy -- -D warnings`)
- [ ] WASM builds successfully (if applicable)

## Breaking Changes

<!-- If this introduces breaking changes, describe them here -->

- [ ] This PR includes breaking changes
- [ ] Documentation has been updated to reflect breaking changes
- [ ] Migration guide included (if needed)

## Additional Notes

<!-- Any additional information, context, or screenshots -->
