### PR TITLE
feat(evaluation): pre-evaluate static flags for host-side caching

### DIFF
--- a/java/src/main/java/dev/openfeature/flagd/evaluator/UpdateStateResult.java
+++ b/java/src/main/java/dev/openfeature/flagd/evaluator/UpdateStateResult.java
@@ -2,6 +2,7 @@ package dev.openfeature.flagd.evaluator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Result of updating flag state.
@@ -14,6 +15,8 @@ public class UpdateStateResult {
     private String error;
 
     private List<String> changedFlags;
+
+    private Map<String, EvaluationResult<Object>> preEvaluated;
 
     public UpdateStateResult() {
     }
@@ -57,6 +60,22 @@ public class UpdateStateResult {
 
     public void setChangedFlags(List<String> changedFlags) {
         this.changedFlags = changedFlags;
+    }
+
+    /**
+     * Gets the pre-evaluated results for static and disabled flags.
+     *
+     * <p>These flags don't require targeting evaluation, so their results are
+     * computed during {@code updateState()} to allow host-side caching.
+     *
+     * @return map of flag key to pre-evaluated result, or null if none
+     */
+    public Map<String, EvaluationResult<Object>> getPreEvaluated() {
+        return preEvaluated;
+    }
+
+    public void setPreEvaluated(Map<String, EvaluationResult<Object>> preEvaluated) {
+        this.preEvaluated = preEvaluated;
     }
 
     @Override

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,7 +7,9 @@ mod feature_flag;
 
 pub use feature_flag::{FeatureFlag, ParsingResult};
 
+use crate::types::EvaluationResult;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Response from updating flag state indicating which flags have changed.
 ///
@@ -25,4 +27,12 @@ pub struct UpdateStateResponse {
     /// List of flag keys that were changed (added, removed, or mutated)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changed_flags: Option<Vec<String>>,
+
+    /// Pre-evaluated results for static and disabled flags.
+    ///
+    /// These flags don't require targeting evaluation, so their results are
+    /// computed during `update_state()` to allow host-side caching and avoid
+    /// WASM boundary overhead on every evaluation call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_evaluated: Option<HashMap<String, EvaluationResult>>,
 }


### PR DESCRIPTION
## Summary

- Pre-evaluate static (no targeting) and disabled flags during `update_state()` and return results in the response
- Java `FlagEvaluator` caches these results and returns them directly from `evaluateFlag()`, skipping the WASM boundary entirely
- Updates Java README with JMH benchmark comparison data (WASM vs native JsonLogic)

## Motivation

JMH benchmarks showed a **~200x latency gap** for simple flags: native JsonLogic at 0.022 µs/op vs WASM at 4.41 µs/op. The overhead comes from JSON serialization across the WASM boundary — but static flags don't need any of that, they always return the same result.

## Changes

### Rust
- `src/model/mod.rs`: Added `pre_evaluated: Option<HashMap<String, EvaluationResult>>` to `UpdateStateResponse`
- `src/evaluator.rs`: Added `pre_evaluate_static_flags()` that evaluates all static/disabled flags with empty context during `update_state()`

### Java
- `UpdateStateResult.java`: Added `preEvaluated` map field
- `FlagEvaluator.java`: Added `volatile` cache populated on `updateState()`, checked first in `evaluateFlag()` — cache hit skips WASM entirely
- `README.md`: Updated Performance section with benchmark comparison tables

### Expected performance impact

| Scenario | Before | After |
|---|---|---|
| Simple flag (no targeting) | ~4.41 µs/op | ~0.02 µs/op (HashMap lookup) |
| Disabled flag | ~4.41 µs/op | ~0.02 µs/op (HashMap lookup) |
| Targeting flag | ~26 µs/op | ~26 µs/op (unchanged) |

## Test plan

- [x] `cargo test` — all Rust tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `./mvnw test` — all 30 Java tests pass (existing tests exercise static flags via cache)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)