### PR TITLE
perf(rust): add scale benchmarks S6-S8, S10-S11 for large flag stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +231,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +353,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,7 +437,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "linked-hash-map",
  "pin-project",
  "ref-cast",
@@ -385,7 +454,7 @@ checksum = "5a1afaf9c422380861111c6be56f39b324e351fd9efc07a1486268798bf79cfd"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -497,6 +566,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "boon",
+ "criterion",
  "cucumber",
  "datalogic-rs",
  "getrandom 0.3.4",
@@ -710,10 +780,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
@@ -888,10 +975,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1120,6 +1227,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1395,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "ref-cast"
@@ -1585,6 +1740,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ harness = false
 name = "comparison"
 harness = false
 
+[[bench]]
+name = "scale"
+harness = false
+
 [profile.release]
 # Optimize for speed instead of size for better runtime performance
 opt-level = 2

--- a/benches/scale.rs
+++ b/benches/scale.rs
@@ -1,0 +1,130 @@
+//! Scale benchmarks for large flag stores (S6-S11).
+//!
+//! Tests update_state performance at 1K, 10K, and 100K flags, and verifies
+//! O(1) evaluation lookup from a 10K-flag store for both static and targeting flags.
+//! Flag distributions approximate production workloads: 70% static, 25% targeting, 5% disabled.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use flagd_evaluator::{FlagEvaluator, ValidationMode};
+use serde_json::json;
+use std::time::Duration;
+
+/// Generates a flag configuration JSON string with the specified number of flags.
+///
+/// Distribution:
+/// - 70% static (ENABLED, no targeting)
+/// - 25% simple targeting (single `==` condition)
+/// - 5% disabled
+///
+/// Flag names follow the pattern `flag_0001`, `flag_0002`, etc.
+fn generate_scale_config(num_flags: usize) -> String {
+    let mut buf = String::with_capacity(num_flags * 200);
+    buf.push_str(r#"{"flags":{"#);
+
+    for i in 0..num_flags {
+        if i > 0 {
+            buf.push(',');
+        }
+
+        let name = format!("flag_{:04}", i);
+        let category = i % 20; // deterministic distribution
+
+        if category < 14 {
+            // 70% static flags (0-13 out of 0-19)
+            buf.push_str(&format!(
+                r#""{name}":{{"state":"ENABLED","variants":{{"on":true,"off":false}},"defaultVariant":"on"}}"#
+            ));
+        } else if category < 19 {
+            // 25% targeting flags (14-18 out of 0-19)
+            buf.push_str(&format!(
+                r#""{name}":{{"state":"ENABLED","variants":{{"on":true,"off":false}},"defaultVariant":"off","targeting":{{"if":[{{"==":[{{"var":"color"}},"blue"]}},"on","off"]}}}}"#
+            ));
+        } else {
+            // 5% disabled flags (19 out of 0-19)
+            buf.push_str(&format!(
+                r#""{name}":{{"state":"DISABLED","variants":{{"on":true,"off":false}},"defaultVariant":"on"}}"#
+            ));
+        }
+    }
+
+    buf.push_str("}}");
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// S6-S8: update_state at scale
+// ---------------------------------------------------------------------------
+
+fn bench_update_state_scale(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scale_update_state");
+
+    for &(size, label, sample_size) in &[
+        (1_000, "S6_1K", 50),
+        (10_000, "S7_10K", 10),
+        (100_000, "S8_100K", 10),
+    ] {
+        let config = generate_scale_config(size);
+
+        group.sample_size(sample_size);
+        // Give S8 more time to complete
+        if size >= 100_000 {
+            group.measurement_time(Duration::from_secs(30));
+        } else if size >= 10_000 {
+            group.measurement_time(Duration::from_secs(15));
+        }
+
+        group.bench_with_input(BenchmarkId::new("fresh", label), &config, |b, config| {
+            b.iter_batched(
+                || FlagEvaluator::new(ValidationMode::Permissive),
+                |mut evaluator| {
+                    evaluator.update_state(black_box(config)).unwrap();
+                },
+                criterion::BatchSize::PerIteration,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// S10-S11: Evaluate from a large (10K) flag store
+// ---------------------------------------------------------------------------
+
+/// S10: Evaluate a static flag from a 10K-flag store.
+/// Verifies that flag lookup is O(1) regardless of store size.
+fn bench_evaluate_static_from_10k(c: &mut Criterion) {
+    let config = generate_scale_config(10_000);
+    let mut evaluator = FlagEvaluator::new(ValidationMode::Permissive);
+    evaluator.update_state(&config).unwrap();
+
+    // flag_0000 is a static flag (index 0, 0 % 20 == 0, which is < 14 -> static)
+    let context = json!({});
+
+    c.bench_function("S10_evaluate_static_from_10K_store", |b| {
+        b.iter(|| evaluator.evaluate_flag(black_box("flag_0000"), black_box(&context)))
+    });
+}
+
+/// S11: Evaluate a targeting flag from a 10K-flag store.
+/// Verifies that targeting evaluation is O(1) regardless of store size.
+fn bench_evaluate_targeting_from_10k(c: &mut Criterion) {
+    let config = generate_scale_config(10_000);
+    let mut evaluator = FlagEvaluator::new(ValidationMode::Permissive);
+    evaluator.update_state(&config).unwrap();
+
+    // flag_0014 is a targeting flag (index 14, 14 % 20 == 14, which is >= 14 and < 19 -> targeting)
+    let context = json!({"color": "blue", "targetingKey": "user-123"});
+
+    c.bench_function("S11_evaluate_targeting_from_10K_store", |b| {
+        b.iter(|| evaluator.evaluate_flag(black_box("flag_0014"), black_box(&context)))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_update_state_scale,
+    bench_evaluate_static_from_10k,
+    bench_evaluate_targeting_from_10k,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Adds criterion benchmarks for large flag configurations (1K–100K flags)
- Confirms O(1) evaluation lookup at scale — no degradation with 10K flags in store
- Flag generation uses production-like distribution: 70% static, 25% targeting, 5% disabled

## Benchmarks Added

| ID | Scenario | Result |
|----|----------|--------|
| S6 | `update_state` with 1,000 flags | ~9.3 ms |
| S7 | `update_state` with 10,000 flags | (longer run) |
| S8 | `update_state` with 100,000 flags | (longer run) |
| S10 | Evaluate static flag from 10K store | ~101 ns |
| S11 | Evaluate targeting flag from 10K store | ~665 ns |

S9 (1M flags) skipped as it may be too slow for CI.

## Run

```bash
cargo bench -- scale
```

## Test plan

- [x] `cargo bench -- S6` runs and produces results
- [x] S10/S11 confirm O(1) lookup (comparable to baseline evaluation benchmarks)
- [x] `cargo test --lib -- --test-threads=1` — all existing tests pass

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)