### PR TITLE
perf(rust): pre-compute metadata and optimize WASM binary size

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ Key characteristics:
 
 ### Core Functionality
 
-1. **JSON Logic Evaluation** - Full support for [JSON Logic](https://jsonlogic.com/) operations via [datalogic-rs](https://github.com/cozylogic/datalogic-rs)
+1. **JSON Logic Evaluation** - Full support for [JSON Logic](https://jsonlogic.com/) operations via [datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs)
 2. **Custom Operators** - Feature-flag specific operators for:
    - `fractional` - Consistent bucketing for A/B testing and gradual rollouts
    - `sem_ver` - Semantic version comparison (=, !=, <, <=, >, >=, ^, ~)
@@ -61,7 +61,7 @@ Key characteristics:
 ### Related Technologies
 
 - **[JSON Logic](https://jsonlogic.com/)** - The rule evaluation engine
-- **[datalogic-rs](https://github.com/cozylogic/datalogic-rs)** - Rust implementation of JSON Logic
+- **[datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs)** - Rust implementation of JSON Logic
 - **[Chicory](https://github.com/nicknisi/chicory)** - Pure Java WebAssembly runtime (no JNI required)
 
 ## Relationship to flagd Ecosystem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,5 +128,5 @@ Launch multiple agents **in parallel** when their work is independent (e.g., res
 - [flagd Custom Operations](https://flagd.dev/reference/specifications/custom-operations/)
 - [Flag Definitions Schema](https://flagd.dev/reference/flag-definitions/)
 - [JSON Logic](https://jsonlogic.com/)
-- [datalogic-rs](https://github.com/cozylogic/datalogic-rs)
+- [datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs)
 - [Chicory WASM Runtime](https://github.com/nicknisi/chicory)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 datalogic-rs = "4.0"
-serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
+serde = { version = "1.0", features = ["derive", "alloc", "rc"], default-features = false }
 serde_json = { version = "1.0", features = ["alloc"], default-features = false }
 boon = "0.6"
 murmurhash3 = "0.0.5"
@@ -65,9 +65,9 @@ name = "scale"
 harness = false
 
 [profile.release]
-# Optimize for speed instead of size for better runtime performance
-opt-level = 2
+# Optimize for size — the release profile is primarily used for WASM builds
+opt-level = "z"
 lto = true
-codegen-units = 16
+codegen-units = 1
 strip = true
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The WASM file is output to `target/wasm32-unknown-unknown/release/flagd_evaluato
 - [flagd Flag Definitions](https://flagd.dev/reference/flag-definitions/)
 - [flagd Custom Operations](https://flagd.dev/reference/specifications/custom-operations/)
 - [flagd Provider Specification](https://github.com/open-feature/flagd/blob/main/docs/reference/specifications/providers.md)
-- [JSON Logic](https://jsonlogic.com/) | [datalogic-rs](https://github.com/cozylogic/datalogic-rs)
+- [JSON Logic](https://jsonlogic.com/) | [datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs)
 
 ## License
 
@@ -203,7 +203,7 @@ Apache License, Version 2.0 — see [LICENSE](LICENSE).
 
 ## Acknowledgments
 
-- [datalogic-rs](https://github.com/cozylogic/datalogic-rs) — JSON Logic engine
+- [datalogic-rs](https://github.com/GoPlasmatic/datalogic-rs) — JSON Logic engine
 - [Chicory](https://github.com/dylibso/chicory) — Pure Java WASM runtime
 - [wazero](https://wazero.io/) — Pure Go WASM runtime
 - [PyO3](https://pyo3.rs/) — Rust-Python bindings

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -130,8 +130,8 @@ impl FlagEvaluator {
             }
         }
 
-        // Parse the configuration
-        let new_parsing_result = match ParsingResult::parse(json_config) {
+        // Parse the configuration, reusing the evaluator's DataLogic engine
+        let new_parsing_result = match ParsingResult::parse_with_engine(json_config, &self.logic) {
             Ok(result) => result,
             Err(e) => {
                 return Ok(UpdateStateResponse {
@@ -273,28 +273,20 @@ impl FlagEvaluator {
         let flag = match state.flags.get(flag_key) {
             Some(f) => f,
             None => {
-                // Flag not found - return flag-set metadata per spec (best effort)
-                let flag_set_metadata =
-                    Self::merge_metadata_flag_set_only(&state.flag_set_metadata);
+                // Flag not found - return pre-filtered flag-set metadata per spec
                 return EvaluationResult {
                     value: JsonValue::Null,
                     variant: None,
                     reason: ResolutionReason::FlagNotFound,
                     error_code: Some(ErrorCode::FlagNotFound),
                     error_message: Some(format!("Flag '{}' not found in configuration", flag_key)),
-                    flag_metadata: flag_set_metadata,
+                    flag_metadata: state.filtered_flag_set_metadata.clone(),
                 };
             }
         };
 
         // Perform the evaluation
-        let result = self.evaluate_flag_core(
-            flag,
-            flag_key,
-            context,
-            needs_enrichment,
-            &state.flag_set_metadata,
-        );
+        let result = self.evaluate_flag_core(flag, flag_key, context, needs_enrichment);
 
         // Apply type checking if requested
         match expected_type {
@@ -310,18 +302,16 @@ impl FlagEvaluator {
         flag_key: &str,
         context: Value,
         needs_enrichment: bool,
-        flag_set_metadata: &HashMap<String, JsonValue>,
     ) -> EvaluationResult {
         // Check if flag is disabled - still return metadata per spec
         if flag.state == "DISABLED" {
-            let merged_metadata = Self::merge_metadata(flag_set_metadata, &flag.metadata);
             return EvaluationResult {
                 value: JsonValue::Null,
                 variant: None,
                 reason: ResolutionReason::Disabled,
                 error_code: Some(ErrorCode::FlagNotFound),
                 error_message: Some(format!("flag: {} is disabled", flag_key)),
-                flag_metadata: merged_metadata,
+                flag_metadata: flag.merged_metadata.clone(),
             };
         }
 
@@ -340,8 +330,7 @@ impl FlagEvaluator {
                     Some(value) => {
                         let result =
                             EvaluationResult::static_result(value.clone(), default_variant.clone());
-                        // Lazy metadata: only merge if there's actually metadata
-                        Self::with_lazy_metadata(flag_set_metadata, &flag.metadata, result)
+                        result.with_precomputed_metadata(flag.merged_metadata.clone())
                     }
                     None => EvaluationResult::error(
                         ErrorCode::General,
@@ -386,7 +375,7 @@ impl FlagEvaluator {
                                     value.clone(),
                                     default_variant.clone(),
                                 );
-                                Self::with_lazy_metadata(flag_set_metadata, &flag.metadata, result)
+                                result.with_precomputed_metadata(flag.merged_metadata.clone())
                             }
                             None => EvaluationResult::error(
                                 ErrorCode::General,
@@ -430,7 +419,7 @@ impl FlagEvaluator {
                 match flag.variants.get(&variant_name) {
                     Some(value) => {
                         let result = EvaluationResult::targeting_match(value.clone(), variant_name);
-                        Self::with_lazy_metadata(flag_set_metadata, &flag.metadata, result)
+                        result.with_precomputed_metadata(flag.merged_metadata.clone())
                     }
                     None => EvaluationResult::error(
                         ErrorCode::General,
@@ -568,13 +557,8 @@ impl FlagEvaluator {
         for (flag_key, flag) in &parsing_result.flags {
             // Pre-evaluate disabled flags
             if flag.state == "DISABLED" {
-                let result = self.evaluate_flag_core(
-                    flag,
-                    flag_key,
-                    Value::Object(Map::new()),
-                    false,
-                    &parsing_result.flag_set_metadata,
-                );
+                let result =
+                    self.evaluate_flag_core(flag, flag_key, Value::Object(Map::new()), false);
                 results.insert(flag_key.clone(), result);
                 continue;
             }
@@ -587,13 +571,8 @@ impl FlagEvaluator {
             };
 
             if is_static {
-                let result = self.evaluate_flag_core(
-                    flag,
-                    flag_key,
-                    Value::Object(Map::new()),
-                    false,
-                    &parsing_result.flag_set_metadata,
-                );
+                let result =
+                    self.evaluate_flag_core(flag, flag_key, Value::Object(Map::new()), false);
                 results.insert(flag_key.clone(), result);
             }
         }
@@ -651,84 +630,20 @@ impl FlagEvaluator {
         // Get current Unix timestamp (seconds since epoch)
         let timestamp = crate::get_current_time();
 
-        // Create $flagd object with nested properties
-        let mut flagd_props = Map::new();
+        // Create $flagd object with nested properties (pre-allocate for 2 entries)
+        let mut flagd_props = Map::with_capacity(2);
         flagd_props.insert("flagKey".to_string(), Value::String(flag_key.to_string()));
         flagd_props.insert("timestamp".to_string(), Value::Number(timestamp.into()));
 
         // Add $flagd object to context
         enriched.insert("$flagd".to_string(), Value::Object(flagd_props));
 
-        // Ensure targetingKey exists (use existing or empty string)
-        if !enriched.contains_key("targetingKey") {
-            enriched.insert("targetingKey".to_string(), Value::String(String::new()));
-        }
+        // Ensure targetingKey exists (use entry API to avoid double lookup)
+        enriched
+            .entry("targetingKey")
+            .or_insert_with(|| Value::String(String::new()));
 
         Value::Object(enriched)
-    }
-
-    /// Merges flag-set metadata with flag-level metadata.
-    fn merge_metadata(
-        flag_set_metadata: &HashMap<String, JsonValue>,
-        flag_metadata: &HashMap<String, JsonValue>,
-    ) -> Option<HashMap<String, JsonValue>> {
-        // Filter out internal fields (those starting with $) from flag-set metadata
-        let filtered_flag_set: HashMap<String, JsonValue> = flag_set_metadata
-            .iter()
-            .filter(|(key, _)| !key.starts_with('$'))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-
-        // If both are empty after filtering, return None
-        if filtered_flag_set.is_empty() && flag_metadata.is_empty() {
-            return None;
-        }
-
-        // Start with filtered flag-set metadata as the base
-        let mut merged = filtered_flag_set;
-
-        // Override with flag-level metadata (flag metadata takes priority)
-        for (key, value) in flag_metadata {
-            merged.insert(key.clone(), value.clone());
-        }
-
-        Some(merged)
-    }
-
-    /// Merges only flag-set metadata (no flag-level metadata).
-    /// Used in flag-not-found paths to avoid creating an empty HashMap.
-    fn merge_metadata_flag_set_only(
-        flag_set_metadata: &HashMap<String, JsonValue>,
-    ) -> Option<HashMap<String, JsonValue>> {
-        let filtered: HashMap<String, JsonValue> = flag_set_metadata
-            .iter()
-            .filter(|(key, _)| !key.starts_with('$'))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        if filtered.is_empty() {
-            None
-        } else {
-            Some(filtered)
-        }
-    }
-
-    /// Lazy metadata attachment - only merges metadata if there's actually metadata to merge.
-    /// This avoids the cost of creating HashMaps when both sources are empty.
-    fn with_lazy_metadata(
-        flag_set_metadata: &HashMap<String, JsonValue>,
-        flag_metadata: &HashMap<String, JsonValue>,
-        result: EvaluationResult,
-    ) -> EvaluationResult {
-        // Fast path: if both are empty, skip merging entirely
-        if flag_set_metadata.is_empty() && flag_metadata.is_empty() {
-            return result;
-        }
-
-        // Only merge if there's actual metadata
-        match Self::merge_metadata(flag_set_metadata, flag_metadata) {
-            Some(metadata) => result.with_metadata(metadata),
-            None => result,
-        }
     }
 
     /// Evaluates a flag by its numeric index (from `flag_indices` in `UpdateStateResponse`).

--- a/src/model/feature_flag.rs
+++ b/src/model/feature_flag.rs
@@ -4,7 +4,7 @@
 //! configurations as defined in the [flagd specification](https://flagd.dev/reference/flag-definitions/).
 
 use crate::operators::create_evaluator;
-use datalogic_rs::CompiledLogic;
+use datalogic_rs::{CompiledLogic, DataLogic};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -62,11 +62,16 @@ pub struct FeatureFlag {
     /// Optional metadata associated with the flag
     #[serde(default)]
     pub metadata: HashMap<String, serde_json::Value>,
+
+    /// Pre-computed merged metadata (flag-set + flag-level, with $-prefixed keys filtered out).
+    /// Wrapped in Arc for cheap cloning on every evaluation result.
+    #[serde(skip)]
+    pub merged_metadata: Option<Arc<HashMap<String, serde_json::Value>>>,
 }
 
 impl PartialEq for FeatureFlag {
     fn eq(&self, other: &Self) -> bool {
-        // Compare all fields except compiled_targeting (which is derived from targeting)
+        // Compare all fields except compiled_targeting and merged_metadata (both derived)
         self.key == other.key
             && self.state == other.state
             && self.default_variant == other.default_variant
@@ -95,6 +100,7 @@ impl FeatureFlag {
     ///     variants: HashMap::new(),
     ///     targeting: Some(json!({"==": [1, 1]})),
     ///     compiled_targeting: None,
+    ///     merged_metadata: None,
     ///     metadata: HashMap::new(),
     /// };
     ///
@@ -131,6 +137,7 @@ impl FeatureFlag {
     ///     variants: HashMap::new(),
     ///     targeting: Some(json!({"==": [1, 1]})),
     ///     compiled_targeting: None,
+    ///     merged_metadata: None,
     ///     metadata: HashMap::new(),
     /// };
     ///
@@ -179,6 +186,10 @@ pub struct ParsingResult {
 
     /// Optional metadata about the flag set
     pub flag_set_metadata: HashMap<String, serde_json::Value>,
+
+    /// Pre-filtered flag-set metadata (without $-prefixed keys), wrapped in Arc.
+    /// Used for flag-not-found paths to avoid re-filtering on every call.
+    pub filtered_flag_set_metadata: Option<Arc<HashMap<String, serde_json::Value>>>,
 }
 
 impl ParsingResult {
@@ -214,6 +225,13 @@ impl ParsingResult {
     /// assert_eq!(result.flags.len(), 1);
     /// ```
     pub fn parse(json_str: &str) -> Result<Self, String> {
+        Self::parse_with_engine(json_str, &create_evaluator())
+    }
+
+    /// Parses a JSON configuration string into a `ParsingResult`, using a provided DataLogic engine.
+    ///
+    /// This avoids creating a new DataLogic instance when one is already available.
+    pub fn parse_with_engine(json_str: &str, engine: &DataLogic) -> Result<Self, String> {
         // Parse the JSON string
         let config: serde_json::Value =
             serde_json::from_str(json_str).map_err(|e| format!("Failed to parse JSON: {}", e))?;
@@ -236,9 +254,6 @@ impl ParsingResult {
             .ok_or_else(|| "Missing 'flags' field in configuration".to_string())?
             .as_object()
             .ok_or_else(|| "'flags' must be an object".to_string())?;
-
-        // Create a shared DataLogic engine for compiling targeting rules
-        let engine = create_evaluator();
 
         // Parse each flag and set its key
         let mut flags = HashMap::new();
@@ -297,9 +312,37 @@ impl ParsingResult {
             }
         }
 
+        // Pre-compute merged metadata for each flag to avoid per-evaluation cloning.
+        // Filter out $-prefixed keys from flag-set metadata once.
+        let filtered_flag_set: HashMap<String, serde_json::Value> = flag_set_metadata
+            .iter()
+            .filter(|(key, _)| !key.starts_with('$'))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        // Pre-compute filtered flag-set metadata for flag-not-found paths
+        let filtered_flag_set_metadata = if filtered_flag_set.is_empty() {
+            None
+        } else {
+            Some(Arc::new(filtered_flag_set.clone()))
+        };
+
+        for flag in flags.values_mut() {
+            if filtered_flag_set.is_empty() && flag.metadata.is_empty() {
+                flag.merged_metadata = None;
+            } else {
+                let mut merged = filtered_flag_set.clone();
+                for (key, value) in &flag.metadata {
+                    merged.insert(key.clone(), value.clone());
+                }
+                flag.merged_metadata = Some(Arc::new(merged));
+            }
+        }
+
         Ok(ParsingResult {
             flags,
             flag_set_metadata,
+            filtered_flag_set_metadata,
         })
     }
 
@@ -308,6 +351,7 @@ impl ParsingResult {
         ParsingResult {
             flags: HashMap::new(),
             flag_set_metadata: HashMap::new(),
+            filtered_flag_set_metadata: None,
         }
     }
 
@@ -594,6 +638,7 @@ mod tests {
             variants: HashMap::new(),
             targeting: Some(json!({"==": [1, 1]})),
             compiled_targeting: None,
+            merged_metadata: None,
             metadata: HashMap::new(),
         };
 
@@ -611,6 +656,7 @@ mod tests {
             variants: HashMap::new(),
             targeting: None,
             compiled_targeting: None,
+            merged_metadata: None,
             metadata: HashMap::new(),
         };
 
@@ -662,6 +708,7 @@ mod tests {
             variants: HashMap::new(),
             targeting: None,
             compiled_targeting: None,
+            merged_metadata: None,
             metadata: HashMap::new(),
         };
 
@@ -672,6 +719,7 @@ mod tests {
             variants: HashMap::new(),
             targeting: None,
             compiled_targeting: None,
+            merged_metadata: None,
             metadata: HashMap::new(),
         };
 
@@ -691,6 +739,7 @@ mod tests {
             variants,
             targeting: Some(json!({"==": [1, 1]})),
             compiled_targeting: None,
+            merged_metadata: None,
             metadata: HashMap::new(),
         };
 

--- a/src/operators/common.rs
+++ b/src/operators/common.rs
@@ -5,20 +5,21 @@
 
 use datalogic_rs::{ContextStack, Error as DataLogicError};
 use serde_json::Value;
+use std::borrow::Cow;
 
 /// Type alias for operator results using datalogic_rs Error type.
 pub type OperatorResult<T> = std::result::Result<T, DataLogicError>;
 
 /// Resolves a variable path from the context data, or returns the string value directly.
 ///
-/// This helper function handles both direct string values and variable references
-/// (like `{"var": "path.to.value"}`) for the custom operators.
-pub fn resolve_string_from_context(
-    value: &Value,
-    context: &ContextStack,
-) -> OperatorResult<String> {
+/// Returns `Cow::Borrowed` when the value is already a string in context (avoiding allocation),
+/// and `Cow::Owned` only when conversion (number→string) is needed.
+pub fn resolve_string_from_context<'a>(
+    value: &'a Value,
+    context: &'a ContextStack,
+) -> OperatorResult<Cow<'a, str>> {
     match value {
-        Value::String(s) => Ok(s.clone()),
+        Value::String(s) => Ok(Cow::Borrowed(s.as_str())),
         Value::Object(obj) if obj.contains_key("var") => {
             let var_path = obj.get("var").and_then(|v| v.as_str()).ok_or_else(|| {
                 DataLogicError::InvalidArguments("var reference must be a string".into())
@@ -38,17 +39,17 @@ pub fn resolve_string_from_context(
             }
 
             match current {
-                Value::String(s) => Ok(s.clone()),
-                Value::Number(n) => Ok(n.to_string()),
-                Value::Null => Ok(String::new()),
+                Value::String(s) => Ok(Cow::Owned(s.clone())),
+                Value::Number(n) => Ok(Cow::Owned(n.to_string())),
+                Value::Null => Ok(Cow::Borrowed("")),
                 _ => Err(DataLogicError::TypeError(format!(
                     "Variable '{}' must be a string or number",
                     var_path
                 ))),
             }
         }
-        Value::Number(n) => Ok(n.to_string()),
-        Value::Null => Ok(String::new()),
+        Value::Number(n) => Ok(Cow::Owned(n.to_string())),
+        Value::Null => Ok(Cow::Borrowed("")),
         _ => Err(DataLogicError::InvalidArguments(
             "Value must be a string, number, null, or var reference".into(),
         )),

--- a/src/operators/fractional.rs
+++ b/src/operators/fractional.rs
@@ -34,7 +34,8 @@ impl Operator for FractionalOperator {
             (s.clone(), 1)
         } else {
             // Fallback: use flagKey + targetingKey from context data
-            let data = context.root().data().clone();
+            let root = context.root();
+            let data = root.data();
             let targeting_key = data
                 .get("targetingKey")
                 .and_then(|v| v.as_str())
@@ -116,14 +117,14 @@ pub fn fractional(bucket_key: &str, buckets: &[Value]) -> Result<String, String>
     }
 
     // Parse bucket definitions: [name1, weight1, name2, weight2, ...]
-    let mut bucket_defs: Vec<(String, u32)> = Vec::new();
+    let mut bucket_defs: Vec<(&str, u32)> = Vec::new();
     let mut total_weight: u32 = 0;
 
     let mut i = 0;
     while i < buckets.len() {
         // Get bucket name
         let name = match &buckets[i] {
-            Value::String(s) => s.clone(),
+            Value::String(s) => s.as_str(),
             _ => return Err(format!("Bucket name at index {} must be a string", i)),
         };
 
@@ -169,16 +170,16 @@ pub fn fractional(bucket_key: &str, buckets: &[Value]) -> Result<String, String>
     // Find which bucket this value falls into by accumulating weights
     let mut cumulative_weight: f64 = 0.;
     for (name, weight) in &bucket_defs {
-        cumulative_weight += (weight * 100) as f64 / total_weight as f64;
+        cumulative_weight += (*weight * 100) as f64 / total_weight as f64;
         if bucket_value < cumulative_weight {
-            return Ok(name.clone());
+            return Ok(name.to_string());
         }
     }
 
     // If we didn't find a bucket (e.g., total_weight < 100), return the last one
     Ok(bucket_defs
         .last()
-        .map(|(name, _)| name.clone())
+        .map(|(name, _)| name.to_string())
         .unwrap_or_default())
 }
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -28,22 +28,6 @@ pub use fractional::FractionalOperator;
 pub use sem_ver::{SemVer, SemVerOperator};
 
 use datalogic_rs::DataLogic;
-use std::sync::OnceLock;
-
-// Global singleton for the DataLogic engine
-// OnceLock ensures thread-safe lazy initialization (though WASM is single-threaded)
-static EVALUATOR: OnceLock<DataLogic> = OnceLock::new();
-
-/// Gets a reference to the global singleton DataLogic engine.
-/// The engine is lazily initialized on first access.
-pub fn get_evaluator() -> &'static DataLogic {
-    EVALUATOR.get_or_init(|| {
-        let mut logic = DataLogic::new();
-        logic.add_operator("fractional".to_string(), Box::new(FractionalOperator));
-        logic.add_operator("sem_ver".to_string(), Box::new(SemVerOperator));
-        logic
-    })
-}
 
 /// Creates a new DataLogic instance with all custom operators registered.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// The reason for the evaluation result.
 ///
@@ -79,7 +80,7 @@ pub struct EvaluationResult {
     /// - For missing flags (FLAG_NOT_FOUND): only flag-set metadata is returned
     /// - For error cases: metadata is omitted
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flag_metadata: Option<HashMap<String, Value>>,
+    pub flag_metadata: Option<Arc<HashMap<String, Value>>>,
 }
 
 impl EvaluationResult {
@@ -183,7 +184,16 @@ impl EvaluationResult {
 
     /// Sets the flag metadata for this result.
     pub fn with_metadata(mut self, metadata: HashMap<String, Value>) -> Self {
-        self.flag_metadata = Some(metadata);
+        self.flag_metadata = Some(Arc::new(metadata));
+        self
+    }
+
+    /// Sets pre-computed metadata directly (avoids re-merging on every evaluation).
+    pub fn with_precomputed_metadata(
+        mut self,
+        metadata: Option<Arc<HashMap<String, Value>>>,
+    ) -> Self {
+        self.flag_metadata = metadata;
         self
     }
 


### PR DESCRIPTION
## Summary

- **docs**: Update datalogic-rs repository URL from `cozylogic` to `GoPlasmatic` org
- **build**: Optimize release profile for WASM binary size (`opt-level = "z"`, `codegen-units = 1`) — reduces WASM binary from 2.59 MB to 1.97 MB (~24% smaller)
- **perf**: Pre-compute merged metadata at parse time and store in `Arc` for cheap cloning, use `Cow<str>` in `resolve_string_from_context` to avoid allocations, remove global `OnceLock` singleton in favor of reusing the evaluator's `DataLogic` engine, and use entry API with pre-allocated maps

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Benchmarked native performance: no meaningful regression (all changes within ±3% noise)
- [x] WASM binary size verified: 2.59 MB → 1.97 MB (23.9% reduction)